### PR TITLE
sentry-clj.core: fix createSentryClient name error

### DIFF
--- a/src/sentry_clj/core.clj
+++ b/src/sentry_clj/core.clj
@@ -18,7 +18,7 @@
 (def ^:private instance
   "A function which returns a Sentry instance given a DSN."
   (memoize (fn [^String dsn]
-             (.createSentryInstance internal/factory (Dsn. dsn)))))
+             (.createSentryClient internal/factory (Dsn. dsn)))))
 
 (defn- keyword->level
   "Converts a keyword into an event level."


### PR DESCRIPTION
Looks like some find/replace fallout with the change from raven-clj to sentry-clj and raven-java to sentry-java.

sentry-java 1.0.0 doesn't have a SentryClientFactory.createSentryInstance: https://github.com/getsentry/sentry-java/blob/087ccf0fd3d215044367f146ef9fe59200d5b183/sentry/src/main/java/io/sentry/SentryClientFactory.java#L75