### PR TITLE
Fix reflection when handling fingerprints

### DIFF
--- a/src/sentry_clj/core.clj
+++ b/src/sentry_clj/core.clj
@@ -4,7 +4,7 @@
             [clojure.string :as string]
             [clojure.walk :as walk]
             [sentry-clj.internal :as internal])
-  (:import (java.util HashMap Map UUID)
+  (:import (java.util HashMap List Map UUID)
            (io.sentry Sentry)
            (io.sentry.dsn Dsn)
            (io.sentry.event Breadcrumb$Level
@@ -104,7 +104,7 @@
     (when timestamp
       (.withTimestamp b (tc/to-date timestamp)))
     (when (seq fingerprint)
-      (.withFingerprint b fingerprint))
+      (.withFingerprint b ^List fingerprint))
     (.build b)))
 
 (defn init!


### PR DESCRIPTION
This leaves only 2 reflection sources outside of the test suite, of which one requires doing dispatch based on the type (for three versions, which won't be a huge win over the reflection, except it might save some allocation), and the other is actually a Clojure bug to the best of my ability (and #clojure irc last time I encountered it) with proxy-super.