### PR TITLE
Wrap report exceptions bug

### DIFF
--- a/src/sentry_clj/ring.clj
+++ b/src/sentry_clj/ring.clj
@@ -58,5 +58,5 @@
             preprocess-fn
             (request->event e)
             (->> (postprocess-fn req)
-                 (sentry/send-event dsn)))
+                 sentry/send-event))
         (error-fn req e)))))

--- a/test/sentry_clj/ring_test.clj
+++ b/test/sentry_clj/ring_test.clj
@@ -54,7 +54,7 @@
                                                "REMOTE_ADDR" "127.0.0.1"}}
                       :user    {:ip_address "127.0.0.1"}}}
             handler (wrap-report-exceptions wrapped "dsn" {})]
-        (mock! #'sentry/send-event {["dsn" event] nil})
+        (mock! #'sentry/send-event {[event] nil})
         (is (= {:status  500
                 :headers {"Content-Type" "text/html"}
                 :body    "<html><head><title>Error</title></head><body><p>Internal Server Error</p></body></html>"
@@ -80,6 +80,6 @@
                                             {:preprocess-fn  preprocess
                                              :postprocess-fn postprocess
                                              :error-fn       error})]
-        (mock! #'sentry/send-event {["dsn" event] nil})
+        (mock! #'sentry/send-event {[event] nil})
         (is (= (assoc req :exception e)
                (handler req)))))))


### PR DESCRIPTION
The ring exception handler wrapper treats sentry/send-event as if it expects 2 args. Was this previously the case? It seems dsn is now inferred deeper in the call stack.

With these changes my handler is reporting properly in production.