### PR TITLE
bump java version to include new DSN style

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cheshire "5.7.1"]
                  [clj-time "0.13.0"]
-                 [io.sentry/sentry "1.7.3"]
+                 [io.sentry/sentry "1.7.5"]
                  [ring/ring-core "1.6.1" :scope "provided"]]
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]


### PR DESCRIPTION
The current version of the API sends a `InvalidDsnException Invalid DSN, the following properties aren't set '[secret key]'  io.sentry.dsn.Dsn.validate (Dsn.java:212)` thus I took the liberty and updated the Java API version