### PR TITLE
Use `production` as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming
 
-* 3.0.next in progress
+* 3.1.next in progress
   * Added in the ability to define the Environment on configuration of Sentry
     (and not only per-event!)
   * Added in the ability to disable the built-in UncaughtExceptionHandler in
@@ -12,12 +12,11 @@
       an event.
     * An example that registers it's own uncaught exception handler to not
       only log out to sentry, but also to log out to a pre-configured logger.
-  * Bumped `ring/ring-core` to `1.8.2`
 
 ## Stable Builds
 
-* 3.0.0 -- 2020-09-04
-  * Major release bringing compatibility with version 3.0.0 of the Java Sentry
+* 3.1.0 -- 2020-10-16
+  * Major release bringing compatibility with version 3.1.0 of the Java Sentry
     library. This is a **BREAKING** change, insofar that this has only been
     tested with the latest Sentry (20.9.0) and is **not** compatible with
     Sentry 10.0.1 and below. If you wish to use those versions, please

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:paths ["src"]
 
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        cheshire/cheshire {:mvn/version "5.10.0"}
         clojure.java-time/clojure.java-time {:mvn/version "0.3.2"}
-        io.sentry/sentry {:mvn/version "3.0.0"}
+        io.sentry/sentry {:mvn/version "3.1.0"}
         ring/ring-core {:mvn/version "1.8.1"}}
 
  :aliases {:test {:extra-paths ["test"]
-                  :extra-deps {expectations/clojure-test {:mvn/version "1.2.1"}
+                  :extra-deps {cheshire/cheshire {:mvn/version "5.10.0"}
+                               expectations/clojure-test {:mvn/version "1.2.1"}
                                lambdaisland/kaocha {:mvn/version "1.0.700"}
                                lambdaisland/kaocha-cloverage {:mvn/version "1.0.63"}
                                lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>io.sentry</groupId>
   <artifactId>sentry-clj</artifactId>
-  <version>3.0.123-SNAPSHOT</version>
+  <version>3.1.0</version>
   <name>sentry-clj</name>
   <dependencies>
     <dependency>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>clojure.java-time</groupId>
@@ -23,14 +23,9 @@
       <version>0.3.2</version>
     </dependency>
     <dependency>
-      <groupId>cheshire</groupId>
-      <artifactId>cheshire</artifactId>
-      <version>5.10.0</version>
-    </dependency>
-    <dependency>
       <groupId>ring</groupId>
       <artifactId>ring-core</artifactId>
-      <version>1.8.2</version>
+      <version>1.8.1</version>
     </dependency>
   </dependencies>
   <build>
@@ -39,11 +34,11 @@
   <repositories>
     <repository>
       <id>clojars</id>
-      <url>http://nexus/repository/clojars</url>
+      <url>https://repo.clojars.org/</url>
     </repository>
     <repository>
-      <id>nexus</id>
-      <url>http://nexus/repository/maven-public</url>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2/</url>
     </repository>
   </repositories>
 </project>


### PR DESCRIPTION
Also, bring compatibility up to Sentry Java 3.1.0.

Drops an unnecessary dependency on Cheshire (only used for testing)

-=david=-