### PR TITLE
Convert a simple string message into a map to avoid losing events.

### DIFF
--- a/src/sentry_clj/core.clj
+++ b/src/sentry_clj/core.clj
@@ -89,10 +89,13 @@
   "Converts a map into an event."
   [{:keys [event-id message level release environment user request logger platform dist
            tags breadcrumbs server-name extra fingerprints throwable transaction]}]
-  (let [sentry-event (SentryEvent. (DateUtils/getCurrentDateTime))]
+  (let [sentry-event (SentryEvent. (DateUtils/getCurrentDateTime))
+        updated-message (if (string? message)
+                          {:message message}
+                          message)]
     (when event-id
       (.setEventId sentry-event (SentryId. ^UUID event-id)))
-    (when-let [{:keys [formatted message params]} message]
+    (when-let [{:keys [formatted message params]} updated-message]
       (.setMessage sentry-event (doto
                                   (Message.)
                                   (.setFormatted formatted)


### PR DESCRIPTION
Hi Sentry!
not sure if you accept PRs or if this is the right place for this.

i found something that is pretty annoying, It happened a couple of times to me (in production too).

I was using the simplest `send-event` form possible, like this:
```clojure
(sentry-clj.core/capture-event {:message "My error message"})
```
since the message is a simple string instead of a map, sentry-clj reply with an event ID but nothing arrives in my project on sentry.io.
Using this form `(send-event {:message {:message "Msg"}})` seems not only useless but also easy to get wrong.
I often use `capture-event` with a raw string and very rarely with a formatted one.

I see this behaviour changed since version 3.1.135, the events sent with this kind of message are ingested by the server and displayed in my project with a stack trace, but the message string is still missing.

You are also suggesting something similar in this example [here](/getsentry/sentry-clj/blob/master/src/sentry_clj/core.clj#L242), but again, the message is ignored.

Thanks for the awesome tool!
