### PR TITLE
fix: request method as string

### DIFF
--- a/src/sentry_clj/ring.clj
+++ b/src/sentry_clj/ring.clj
@@ -11,7 +11,7 @@
   "Converts a Ring request into an HTTP interface for an event."
   [req]
   {:url (request-url req)
-   :method (:request-method req)
+   :method (-> req :request-method name)
    :data (:params req)
    :query-string (:query-string req "")
    :headers (:headers req)

--- a/test/sentry_clj/ring_test.clj
+++ b/test/sentry_clj/ring_test.clj
@@ -32,7 +32,7 @@
 (def req
   {:scheme :https
    :uri "/hello-world"
-   :method :get
+   :request-method :get
    :params {:one 1}
    :headers {"ok" 2 "host" "example.com"}
    :remote-addr "127.0.0.1"


### PR DESCRIPTION
According to ring [SPEC](https://github.com/ring-clojure/ring/blob/99ece0b95293c6b45e1bdb03a99ab1d597117ac9/SPEC#L73), the key with the request method is called `:request-method`, but the tests were referencing it as `:method`.

The following error (sentry-java expects a String and not a Keyword as HTTP method) was never thrown on tests because of this mistaken setup fixture.
```
Exception: java.lang.ClassCastException: class clojure.lang.Keyword cannot be cast to class java.lang.String (clojure.lang.Keyword is in unnamed module of loader 'app'; java.lang.String is in module java.base of loader 'bootstrap')
```
![image](https://user-images.githubusercontent.com/161157/118559476-59f4c180-b73e-11eb-935f-ed8930f93466.png)

This PR fixes the test setup and the bug