### PR TITLE
Breadcrumb timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ should be a map. Each key is optional.
 - `:message` - a `String`
 - `:category` - a `String`
 - `:data` - a map with `String` keys and `String` values
+- `:timestamp` - a `java.util.Date`
 
 ### Message
 

--- a/src/sentry_clj/core.clj
+++ b/src/sentry_clj/core.clj
@@ -3,7 +3,7 @@
   (:require
    [clojure.walk :as walk])
   (:import
-   [java.util HashMap List Map UUID]
+   [java.util HashMap List Map UUID Date]
    [io.sentry Breadcrumb DateUtils Sentry SentryEvent SentryLevel SentryOptions]
    [io.sentry.protocol Message Request SentryId User]))
 
@@ -32,8 +32,10 @@
 
 (defn ^:private ^Breadcrumb map->breadcrumb
   "Converts a map into a Breadcrumb."
-  [{:keys [type level message category data]}]
-  (let [breadcrumb (Breadcrumb.)]
+  [{:keys [type level message category data timestamp]}]
+  (let [breadcrumb (if timestamp
+                     (Breadcrumb. ^Date timestamp)
+                     (Breadcrumb.))]
     (when type
       (.setType breadcrumb type))
     (when level

--- a/test/sentry_clj/core_test.clj
+++ b/test/sentry_clj/core_test.clj
@@ -9,7 +9,7 @@
     SentryOptions
     SentryLevel]
    [java.io StringWriter]
-   [java.util UUID]))
+   [java.util UUID Date]))
 
 (defexpect keyword->level-test
   (expecting
@@ -48,7 +48,8 @@
                    :level     :info
                    :message   "yes"
                    :category  "maybe"
-                   :data      {"probably" "no"}}]
+                   :data      {"probably" "no"}
+                   :timestamp (Date.)}]
    :server-name  "example.com"
    :fingerprints ["{{ default }}" "nice"]
    :extra        {:one {:two 2}}
@@ -68,12 +69,13 @@
 (defexpect map->breadcrumb-test
   (expecting
    "breadcrumbs"
-   (let [breadcrumb (#'sut/map->breadcrumb {:type "type" :level :info :message "message" :category "category" :data {:a "b" :c "d"}})]
+   (let [breadcrumb (#'sut/map->breadcrumb {:type "type" :level :info :message "message" :category "category" :data {:a "b" :c "d"} :timestamp (Date. 1000000000000)})]
      (expect "type" (.getType breadcrumb))
      (expect SentryLevel/INFO (.getLevel breadcrumb))
      (expect "message" (.getMessage breadcrumb))
      (expect "category" (.getCategory breadcrumb))
-     (expect {"a" "b" "c" "d"} (.getData breadcrumb)))))
+     (expect {"a" "b" "c" "d"} (.getData breadcrumb))
+     (expect (Date. 1000000000000) (.getTimestamp breadcrumb)))))
 
 (defexpect map->user-test
   (expecting


### PR DESCRIPTION
Right now if you send a number of breadcrumbs with an event, they'll all end up on the server with identical timestamps so won't be viewable in chronological order. This PR adds support for an optional explicit `:timestamp` key in breadcrumbs so you can keep track of when breadcrumbs actually happened. It accepts a `java.util.Date` like the underlying sentry-java, although Sentry does support more precision than this.