### PR TITLE
Fix enable to get evaluation result in a child span.

### DIFF
--- a/test/sentry_clj/tracing_test.clj
+++ b/test/sentry_clj/tracing_test.clj
@@ -108,11 +108,17 @@
 
 (defexpect with-start-child-span-test
   (expecting
-   "when a child span is started and works correctly, span status is OK"
+   "when a child span is started and works correctly, the evaluation result is given and span status is OK"
    (let [tr (get-test-sentry-tracer)]
-     (sut/with-start-child-span "op" "desc" (println "hi"))
+     (expect 1 (sut/with-start-child-span "op" "desc" (+ 1 1) (* 1 1)))
      (expect (.getStatus ^Span (nth (.getChildren tr) 0)) (:ok sut/span-status))
      (sut/finish-transaction! tr)))
+  (expecting
+   "when a child span is started with no tracing config, the evaluation result is only given."
+   (let [sentry-option (get-test-options)
+         hub (Hub. sentry-option)]
+     (Sentry/setCurrentHub hub)
+     (expect 1 (sut/with-start-child-span "op" "desc" (+ 1 1) (* 1 1)))))
   (expecting
    "when a child span is started and throw exceptions, span status is INTERNAL_ERROR"
    (let [tr (get-test-sentry-tracer)]


### PR DESCRIPTION
Hi. I''m sorry for sending pull requests repeatedly.
I've made two changes to  the `with-start-child-span` macro

One is that you can get the forms evaluation result which is given as arguments in child span.
Another is that you can evaluate forms even if no tracing setting.