### PR TITLE
Update README: change :fingerprint -> :fingerprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Initialisation with additional options:
 - `:event-id` - a `String` id to use for the event. If not provided, one will be automatically generated.
 - `:extra` - a map with `Keyword` or `String` keys (or anything for which `clojure.core/name` can be invoked) and values which can be JSON-ified. If `:throwable` is given, this will automatically include its `ex-data`.
   - **note**: `:extra` has been deprecated in favour of `:contexts` upon initialisation
-- `:fingerprint` - a sequence of `String`s that Sentry should use as a [fingerprint](https://docs.sentry.io/learn/rollups/#customize-grouping-with-fingerprints).
+- `:fingerprints` - a sequence of `String`s that Sentry should use as a [fingerprint](https://docs.sentry.io/learn/rollups/#customize-grouping-with-fingerprints).
 - `:level` - a `Keyword`. One of `:debug`, `:info`, `:warning`, `:error`, `:fatal`. Probably most useful in conjunction with `:message` if you need to report an exceptional condition that's not an exception.
 - `:logger` - a `String` which identifies the logger.
 - `:message` - a map or `String` containing Message information. See below.


### PR DESCRIPTION
The Sentry event accepts `:fingerprints` rather than `:fingerprint` as it currently says: https://github.com/getsentry/sentry-clj/blob/e5dcf9e64118e4c2c808c188ea5279110c855627/src/sentry_clj/core.clj#L97