### PR TITLE
Preserve keyword namespaces in java-util-hashmappify-vals

### DIFF
--- a/src/sentry_clj/core.clj
+++ b/src/sentry_clj/core.clj
@@ -27,8 +27,8 @@
    on walk/stringify-keys."
   [m]
   (let [f (fn [[k v]]
-            (let [k (if (keyword? k) (name k) k)
-                  v (if (keyword? v) (name v) v)]
+            (let [k (if (keyword? k) (str (symbol k)) k)
+                  v (if (keyword? v) (str (symbol v)) v)]
               (if (map? v) [k (HashMap. ^Map v)] [k v])))]
     (walk/postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))
 

--- a/test/sentry_clj/core_test.clj
+++ b/test/sentry_clj/core_test.clj
@@ -23,7 +23,10 @@
    "everything is a string"
    (expect {"a" "b"} (#'sut/java-util-hashmappify-vals {:a :b}))
    (expect {"a" "b" {"c" "d"} (#'sut/java-util-hashmappify-vals {:a {:b {:c :d}}})})
-   (expect {"var1" "val1" "var2" {"a" {"b" {"c" {"d" {"e" "f"} "g" "h"}}}}} (#'sut/java-util-hashmappify-vals {:var1 "val1" :var2 {:a {:b {:c {:d {:e :f} :g :h}}}}}))))
+   (expect {"var1" "val1" "var2" {"a" {"b" {"c" {"d" {"e" "f"} "g" "h"}}}}} (#'sut/java-util-hashmappify-vals {:var1 "val1" :var2 {:a {:b {:c {:d {:e :f} :g :h}}}}})))
+  (expecting
+   "keyword namespaces are preserved"
+   (expect {"foo/qux" "some/value" "bar/qux" "another/value"} (#'sut/java-util-hashmappify-vals {:foo/qux :some/value :bar/qux :another/value}))))
 
 (def event
   {:event-id     (UUID/fromString "4c4fbea9-57a7-4c99-808d-2284306e6c98")


### PR DESCRIPTION
Without this patch, keys with different namespaces but equal names would non-deterministically clobber each other. Also, namespaces may provide valuable context, so preserving them is generally useful.