### PR TITLE
Preserve ex-data of all ex-info exceptions in the cause chain

### DIFF
--- a/test/sentry_clj/core_test.clj
+++ b/test/sentry_clj/core_test.clj
@@ -206,7 +206,14 @@
 (defexpect map->event-test-with-ex-info
   (expecting
    "an ex-info event"
-   (let [output (serialize (assoc event :throwable (ex-info "bad stuff" {:ex-info 2})))
+   (let [output (serialize (assoc event :throwable (ex-info "bad stuff"
+                                                            {:data 1}
+                                                            (ex-info "this is a transitive cause"
+                                                                     {:data 2}
+                                                                     (RuntimeException.
+                                                                      "this is a non-info transitive cause"
+                                                                      (ex-info "this is the root cause"
+                                                                               {:data 3}))))))
          actual (strip-timestamp output)]
      (expect {"release"     "v1.0.0"
               "event_id"    "4c4fbea957a74c99808d2284306e6c98"
@@ -232,7 +239,9 @@
                              "url" "http://example.com"}
               "transaction" "456"
               "extra"       {"one" {"two" 2}
-                             "ex-info" 2}
+                             "ex-data" {"data" 1}
+                             "ex-data, cause 1: this is a transitive cause" {"data" 2}
+                             "ex-data, cause 3: this is the root cause" {"data" 3}}
               "platform"    "clojure"
               "contexts"    {}
               "breadcrumbs" [{"type"      "http"


### PR DESCRIPTION
Instead of only adding ex-data of the top-level exception into the extra map, walk down the cause chain and add all ex-data encountered therein. To prevent them from clobbering each other or any keys already present in the extra map, nest all ex-data under separate keys. The top-level exception's ex-data is added under "ex-data" while causes are added under `"ex-data, cause <n>: <message>"` where `<n>` is the cause's position in the chain and `<message>` is its message.