### PR TITLE
Allow enabling external configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ If you want an interpolated message, you need to provide the full map, i.e.,
 ## Additional Initialisation Options
 
 | key                                  | description                                                                                                                   | default
-| ------------------------------------ |-------------------------------------------------------------------------------------------------------------------------------| -------
+|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------| -------
+| `:enable-external-configuration`     | Enable loading configuration from the properties file, system properties or environment variables                             | 
 | `:environment`                       | Set the environment on which Sentry events will be logged, e.g., \"production\"                                               | production
 | `:debug`                             | Enable SDK logging at the debug level                                                                                         | false
 | `:release`                           | All events are assigned to a particular release                                                                               |

--- a/src/sentry_clj/core.clj
+++ b/src/sentry_clj/core.clj
@@ -170,7 +170,8 @@
   ^SentryOptions
   ([dsn] (sentry-options dsn {}))
   ([dsn config]
-   (let [{:keys [environment
+   (let [{:keys [enable-external-configuration
+                 environment
                  debug
                  logger
                  diagnostic-level
@@ -195,6 +196,8 @@
 
      (.setDsn sentry-options dsn)
 
+     (when enable-external-configuration
+       (.setEnableExternalConfiguration sentry-options enable-external-configuration))
      (when environment
        (.setEnvironment sentry-options environment))
      ;;
@@ -272,6 +275,7 @@
 
    | key                                  | description                                                                                                        | default
    | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | -------
+   | `:enable-external-configuration`     | Enable loading configuration from the properties file, system properties or environment variables                  |
    | `:environment`                       | Set the environment on which Sentry events will be logged, e.g., \"production\"                                    | production
    | `:enabled`                           | Enable or disable sentry.                                                                                          | true
    | `:debug`                             | Enable SDK logging at the debug level                                                                              | false


### PR DESCRIPTION
When sentry gets initialized, if no option is passed (no-arg `Sentry.init()`), it will call `setEnableExternalConfiguration` with `true`.
The clj library should allow supplying the same option.