### PR TITLE
Add ability to flush events synchronously

### DIFF
--- a/src/sentry_clj/core.clj
+++ b/src/sentry_clj/core.clj
@@ -343,6 +343,13 @@
   []
   (Sentry/close))
 
+(defn flush
+  "Flushes events to Sentry, blocking until the flush is complete.
+
+   You can pass a timeout in milliseconds to wait for the flush to complete."
+  [timeout-millis]
+  (Sentry/flush timeout-millis))
+
 (defn send-event
   "Sends the given event to Sentry, returning the event's id
 


### PR DESCRIPTION
Hello, Sentry.

I’m not sure if I can make a pull request here, but I found an issue when handling sentry-clj with AWS Lambda. The issue is that Sentry event is being shut down by serverless during execution.

I added the flush function, which was updated in sentry-java in 2021, to enable synchronous flushing of Sentry events for AWS Lambda environments. This ensures that all events are sent before the serverless execution is completed, addressing the issue of events not being sent.

### related issue
https://github.com/getsentry/sentry-java/issues/1023

Thanks for your nice tool.
