### PR TITLE
Ensure all keywords are stringified by java-util-hashmappify-vals

### DIFF
--- a/src/sentry_clj/core.clj
+++ b/src/sentry_clj/core.clj
@@ -26,12 +26,16 @@
    values recursively translated into java.util.HashMap objects. Based
    on walk/stringify-keys."
   [m]
-  (let [s (fn [v] (if (keyword? v) (str (symbol v)) v))
-        f (fn [[k v]]
-            (let [k (s k)
-                  v (s v)]
-              (if (map? v) [k (HashMap. ^Map v)] [k v])))]
-    (walk/postwalk (fn [x] (if (map? x) (into {} (map f x)) (s x))) m)))
+  ;; Only inner maps are converted; use plain "walk" on outer map
+  (walk/walk
+   (fn [m]
+     (walk/postwalk (fn [x] (cond
+                              (map? x) (HashMap. ^Map x)
+                              (keyword? x) (str (symbol x))
+                              :else x))
+                    m))
+   identity
+   m))
 
 (defn ^:private map->breadcrumb
   "Converts a map into a Breadcrumb."

--- a/src/sentry_clj/core.clj
+++ b/src/sentry_clj/core.clj
@@ -26,11 +26,12 @@
    values recursively translated into java.util.HashMap objects. Based
    on walk/stringify-keys."
   [m]
-  (let [f (fn [[k v]]
-            (let [k (if (keyword? k) (str (symbol k)) k)
-                  v (if (keyword? v) (str (symbol v)) v)]
+  (let [s (fn [v] (if (keyword? v) (str (symbol v)) v))
+        f (fn [[k v]]
+            (let [k (s k)
+                  v (s v)]
               (if (map? v) [k (HashMap. ^Map v)] [k v])))]
-    (walk/postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))
+    (walk/postwalk (fn [x] (if (map? x) (into {} (map f x)) (s x))) m)))
 
 (defn ^:private map->breadcrumb
   "Converts a map into a Breadcrumb."

--- a/test/sentry_clj/core_test.clj
+++ b/test/sentry_clj/core_test.clj
@@ -23,10 +23,13 @@
    "everything is a string"
    (expect {"a" "b"} (#'sut/java-util-hashmappify-vals {:a :b}))
    (expect {"a" "b" {"c" "d"} (#'sut/java-util-hashmappify-vals {:a {:b {:c :d}}})})
-   (expect {"var1" "val1" "var2" {"a" {"b" {"c" {"d" {"e" "f"} "g" "h"}}}}} (#'sut/java-util-hashmappify-vals {:var1 "val1" :var2 {:a {:b {:c {:d {:e :f} :g :h}}}}})))
+   (expect {"var1" "val1" "var2" {"a" {"b" {"c" {["d" 1] {"e" ["f"]} "g" "h"}}}}} (#'sut/java-util-hashmappify-vals {:var1 "val1" :var2 {:a {:b {:c {[:d 1] {:e [:f]} :g :h}}}}})))
   (expecting
    "keyword namespaces are preserved"
-   (expect {"foo/qux" "some/value" "bar/qux" "another/value"} (#'sut/java-util-hashmappify-vals {:foo/qux :some/value :bar/qux :another/value}))))
+   (expect {"foo/qux" "some/value" "bar/qux" "another/value"} (#'sut/java-util-hashmappify-vals {:foo/qux :some/value :bar/qux :another/value})))
+  (expecting
+   "nested arrays containing keywords are stringified"
+    (expect ["foo/qux" ["some/value" "bar/qux"] [["another/value"]]] (#'sut/java-util-hashmappify-vals [:foo/qux [:some/value :bar/qux] [[:another/value]]]))))
 
 (def event
   {:event-id     (UUID/fromString "4c4fbea9-57a7-4c99-808d-2284306e6c98")


### PR DESCRIPTION
Change `java-util-hashmappify-vals` to also change keywords to strings for lone values nested under a map's direct values.

When `postwalk` would encounter a non-map value, the value would be returned as-is.  This means a keyword which would be nested inside another non-map structure would not be converted to a string.  For maps, if the keys or values are keywords themselves, it would always directly convert them into strings, which masked the problem.

This results in weird-looking serialization which exposes the underlying Java Keyword object, as per #67.