### PR TITLE
Also convert outer maps into HashMap in java-util-hashmappify-vals

### DIFF
--- a/src/sentry_clj/core.clj
+++ b/src/sentry_clj/core.clj
@@ -22,20 +22,16 @@
     SentryLevel/INFO))
 
 (defn java-util-hashmappify-vals
-  "Converts an ordinary Clojure map into a Clojure map with nested map
-   values recursively translated into java.util.HashMap objects. Based
-   on walk/stringify-keys."
+  "Converts an ordinary Clojure map into a java.util.HashMap object.
+   This is done recursively for all nested maps as well.
+   Keywords in any nested values are converted to strings.
+   Based on walk/stringify-keys."
   [m]
-  ;; Only inner maps are converted; use plain "walk" on outer map
-  (walk/walk
-   (fn [m]
-     (walk/postwalk (fn [x] (cond
-                              (map? x) (HashMap. ^Map x)
-                              (keyword? x) (str (symbol x))
-                              :else x))
-                    m))
-   identity
-   m))
+  (walk/postwalk (fn [x] (cond
+                           (map? x) (HashMap. ^Map x)
+                           (keyword? x) (str (symbol x))
+                           :else x))
+                 m))
 
 (defn ^:private map->breadcrumb
   "Converts a map into a Breadcrumb."

--- a/test/sentry_clj/core_test.clj
+++ b/test/sentry_clj/core_test.clj
@@ -25,7 +25,7 @@
    (expecting "nested maps are visited and turned into hashmaps"
      (let [result (#'sut/java-util-hashmappify-vals {:a {:b {:c :d}}})]
        (expect {"a" {"b" {"c" "d"}}} result)
-       (expect clojure.lang.PersistentArrayMap (.getClass result)) ; Outer map is _not_ converted
+       (expect HashMap (.getClass result))
        (expect HashMap (.getClass (get result "a")))
        (expect HashMap (.getClass (get-in result ["a" "b"])))))
    (expect {"var1" "val1" "var2" {"a" {"b" {"c" {["d" 1] {"e" ["f"]} "g" "h"}}}}} (#'sut/java-util-hashmappify-vals {:var1 "val1" :var2 {:a {:b {:c {[:d 1] {:e [:f]} :g :h}}}}})))


### PR DESCRIPTION
This simplifies the code as we don't have to use an extra walk.